### PR TITLE
Optimize CPU Load

### DIFF
--- a/src/site/twitch.tv/TwitchStore.ts
+++ b/src/site/twitch.tv/TwitchStore.ts
@@ -13,7 +13,7 @@ export const useTwitchStore = defineStore("chat", {
 			channel: null,
 			messages: [],
 			messageIds: new Set(),
-			lineLimit: 250,
+			lineLimit: 100,
 			emoteMap: {},
 		} as State),
 
@@ -28,9 +28,13 @@ export const useTwitchStore = defineStore("chat", {
 			this.messages.push(message);
 			this.messageIds.add(message.id);
 
-			if (this.messages.length > this.lineLimit) {
-				const msg = this.messages.shift() as Twitch.ChatMessage;
-				this.messageIds.delete(msg.id);
+			// Clear out messages beyond the limit
+			const overflowLimit = this.lineLimit * 1.25;
+			if (this.messages.length > overflowLimit) {
+				const removed = this.messages.splice(0, this.messages.length - this.lineLimit);
+				for (const m of removed) {
+					this.messageIds.delete(m.id);
+				}
 			}
 		},
 	},

--- a/src/site/twitch.tv/modules/chat/ChatController.vue
+++ b/src/site/twitch.tv/modules/chat/ChatController.vue
@@ -1,14 +1,7 @@
 <template>
 	<Teleport v-if="extMounted && channel && channel.id" :to="containerEl">
 		<div id="seventv-message-container" class="seventv-message-container">
-			<div v-for="msg of chatStore.messages" :key="msg.id" :msg-id="msg.id">
-				<template v-if="msg.seventv">
-					<ChatMessage :msg="msg" @open-viewer-card="openViewerCard" />
-				</template>
-				<template v-else>
-					<ChatMessageUnhandled :msg="msg" />
-				</template>
-			</div>
+			<ChatList :controller="controller" :messages="chatStore.messages" />
 		</div>
 
 		<!-- Data Logic -->
@@ -40,10 +33,9 @@ import { log } from "@/common/Logger";
 import { storeToRefs } from "pinia";
 import { useStore } from "@/store/main";
 import { getRandomInt } from "@/common/Rand";
-import ChatMessage from "@/site/twitch.tv/modules/chat/components/ChatMessage.vue";
-import ChatData from "./ChatData.vue";
-import ChatMessageUnhandled from "./ChatMessageUnhandled.vue";
 import { TransformWorkerMessageType } from "@/worker";
+import ChatData from "./ChatData.vue";
+import ChatList from "./ChatList.vue";
 
 const store = useStore();
 const chatStore = useTwitchStore();
@@ -316,34 +308,6 @@ const resizeObserver = new ResizeObserver(() => {
 	bounds.value = containerEl.value.getBoundingClientRect();
 });
 resizeObserver.observe(containerEl.value);
-
-const openViewerCard = (ev: MouseEvent, viewer: Twitch.ChatUser) => {
-	controller.sendMessage(`/user ${viewer.userLogin}`);
-
-	// Watch for card being created
-	const userCardContainer = document.querySelector("[data-a-target='chat-user-card']");
-	if (!userCardContainer) return;
-
-	const observer = new MutationObserver(() => {
-		// Find card element
-		const cardEl = document.querySelector<HTMLDivElement>("[data-test-selector='viewer-card-positioner']");
-		if (!cardEl) return;
-
-		cardEl.style.top = `${ev.y - cardEl.getBoundingClientRect().height}px`;
-		observer.disconnect();
-		clearTimeout(timeout);
-	});
-
-	observer.observe(userCardContainer, {
-		childList: true,
-		subtree: true,
-	});
-
-	// timeout the mutation observer
-	const timeout = setTimeout(() => {
-		observer.disconnect();
-	}, 30000);
-};
 
 onUnmounted(() => {
 	resizeObserver.disconnect();

--- a/src/site/twitch.tv/modules/chat/ChatList.vue
+++ b/src/site/twitch.tv/modules/chat/ChatList.vue
@@ -1,0 +1,48 @@
+<template>
+	<div v-for="msg of messages" :key="msg.id" :msg-id="msg.id">
+		<template v-if="msg.seventv">
+			<ChatMessage :msg="msg" @open-viewer-card="openViewerCard" />
+		</template>
+		<template v-else>
+			<ChatMessageUnhandled :msg="msg" />
+		</template>
+	</div>
+</template>
+
+<script setup lang="ts">
+import ChatMessage from "@/site/twitch.tv/modules/chat/components/ChatMessage.vue";
+import ChatMessageUnhandled from "./ChatMessageUnhandled.vue";
+
+const props = defineProps<{
+	controller: Twitch.ChatControllerComponent;
+	messages: Twitch.ChatMessage[];
+}>();
+
+const openViewerCard = (ev: MouseEvent, viewer: Twitch.ChatUser) => {
+	props.controller.sendMessage(`/user ${viewer.userLogin}`);
+
+	// Watch for card being created
+	const userCardContainer = document.querySelector("[data-a-target='chat-user-card']");
+	if (!userCardContainer) return;
+
+	const observer = new MutationObserver(() => {
+		// Find card element
+		const cardEl = document.querySelector<HTMLDivElement>("[data-test-selector='viewer-card-positioner']");
+		if (!cardEl) return;
+
+		cardEl.style.top = `${ev.y - cardEl.getBoundingClientRect().height}px`;
+		observer.disconnect();
+		clearTimeout(timeout);
+	});
+
+	observer.observe(userCardContainer, {
+		childList: true,
+		subtree: true,
+	});
+
+	// timeout the mutation observer
+	const timeout = setTimeout(() => {
+		observer.disconnect();
+	}, 30000);
+};
+</script>


### PR DESCRIPTION
Adding a couple optimizations to further reduce CPU load from the chat

- Pass the `Message[]` reactive array as a root prop, so changes to the store don't affect rendering
- Changed the message buffering logic so messages are removed in batches, rather than always removing the last message