### PR TITLE
fix: hook clash by ffz

### DIFF
--- a/src/common/Reflection.ts
+++ b/src/common/Reflection.ts
@@ -84,7 +84,7 @@ export function defineFunctionHook<T extends object>(
 				if (symbol === currentSymbol) {
 					return Reflect.apply(callback, this, [old, ...args]);
 				} else {
-					return old?.apply(old, this, args);
+					return old?.apply(this, args);
 				}
 			};
 		},


### PR DESCRIPTION
Changes the function hook util to always use reflection. This might break other things, need review from @Melonify 